### PR TITLE
Batching api cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "ambassador"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -374,7 +386,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4511823469e9000d277344b2760f22dc0b0d1a9ca86ac4e2ef7c94f8c6d5e404"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "ccp-shared",
  "cmake",
  "hex",
@@ -723,6 +735,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1022,7 @@ name = "fluence-actor-sdk"
 version = "0.1.2"
 dependencies = [
  "fluence-fendermint-shared",
+ "fvm_ipld_encoding",
  "fvm_sdk",
  "fvm_shared",
  "num-traits",
@@ -1012,10 +1038,14 @@ version = "0.1.5"
 dependencies = [
  "ccp-randomx",
  "ccp-shared",
+ "dashmap",
  "fluence-fendermint-shared",
  "fvm",
  "fvm_shared",
+ "hex",
+ "lru",
  "num-traits",
+ "once_cell",
  "rayon",
 ]
 
@@ -1215,7 +1245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f9a003148f592d1b24124b27c9a52f00902b23233515b45b65730dbbfc0c03"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.4.2",
  "blake2b_simd",
  "bls-signatures",
  "cid",
@@ -1251,7 +1281,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "debugid",
  "fxhash",
  "serde",
@@ -1344,6 +1374,10 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1587,6 +1621,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "mach"
@@ -1847,6 +1890,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,7 +2163,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2750,7 +2815,7 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.2",
  "indexmap 2.2.5",
  "semver 1.0.22",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 dependencies = [
  "backtrace",
 ]
@@ -102,7 +102,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byte-slice-cast"
@@ -364,12 +364,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -419,17 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "coarsetime"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b3839cf01bb7960114be3ccf2340f541b6d0c81f8690b007b2b39f750f7e5d"
-dependencies = [
- "libc",
- "wasix",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -601,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -623,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -860,7 +846,7 @@ checksum = "ce8cd46a041ad005ab9c71263f9a0ff5b529eac0fe4cc9b4a20f4f0765d8cf4b"
 dependencies = [
  "execute-command-tokens",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1002,6 +988,7 @@ dependencies = [
  "fvm_shared",
  "num-traits",
  "randomx-rust-wrapper",
+ "rayon",
 ]
 
 [[package]]
@@ -1332,9 +1319,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1388,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1451,9 +1438,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1569,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mach"
@@ -1649,11 +1636,10 @@ dependencies = [
 
 [[package]]
 name = "minstant"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e326a3745e3f61d1715722ed4e72c0e9689aac76f1496c4deeeb64dd68f93fb"
+checksum = "1fb9b5c752f145ac5046bccc3c4f62892e3c950c1d1eab80c5949cd68a2078db"
 dependencies = [
- "coarsetime",
  "ctor",
  "web-time",
 ]
@@ -1750,7 +1736,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1810,9 +1796,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pairing"
@@ -2005,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -2093,9 +2079,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -2105,15 +2091,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -2138,13 +2124,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2161,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -2178,7 +2164,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2449,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2478,15 +2464,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2511,7 +2497,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2578,9 +2564,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -2627,19 +2613,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasix"
-version = "0.12.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
-dependencies = [
- "wasi",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2647,24 +2624,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2672,22 +2649,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
@@ -2723,29 +2700,29 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "semver",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.121.1"
+version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ffe16b4aa1ebab8724f61c9ee38cd5481c89caf10bf1a5af9eab8f0c2e6c05"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
  "bitflags",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "semver",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a76a9228f2e6653f0b3d912b2f3a9b6ac79c690e5642c9ee2dfd914c545cf0"
+checksum = "60e73986a6b7fdfedb7c5bf9e7eb71135486507c8fbc4c0c42cffcb6532988b7"
 dependencies = [
  "anyhow",
- "wasmparser 0.121.1",
+ "wasmparser 0.121.2",
 ]
 
 [[package]]
@@ -2759,7 +2736,7 @@ dependencies = [
  "bumpalo",
  "cfg-if",
  "fxprof-processed-profile",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "libc",
  "log",
  "object 0.31.1",
@@ -2837,7 +2814,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.27.3",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "log",
  "object 0.31.1",
  "serde",
@@ -2901,7 +2878,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "libc",
  "log",
  "mach",
@@ -2939,14 +2916,14 @@ checksum = "ca7af9bb3ee875c4907835e607a275d10b04d15623d3aebe01afe8fbd3f85050"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "web-time"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee269d72cc29bf77a2c4bc689cc750fb39f5cbd493d2205bbb3f5c7779cf7b0"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2989,7 +2966,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3009,17 +2986,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -3030,9 +3007,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3042,9 +3019,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3054,9 +3031,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3066,9 +3043,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3078,9 +3055,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3090,9 +3067,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3102,9 +3079,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "wyz"
@@ -3148,7 +3125,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3168,5 +3145,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "fluence-actor-sdk",
-    "fluence-fendermint-syscall",
-    "shared"
-]
+members = ["fluence-actor-sdk", "fluence-fendermint-syscall", "shared"]
 
 [workspace.dependencies]
 fluence-fendermint-shared = { path = "./shared", version = "0.1.1" }
@@ -14,6 +10,11 @@ ccp-shared = "0.1.0"
 fvm = { version = "4.1.0", default-features = false }
 fvm_shared = "4.1.0"
 fvm_sdk = "4.1.0"
-num-traits = { version = "0.2", default-features = false }
+fvm_ipld_encoding = "0.4.0"
 
+dashmap = "5.5.3"
+hex = "0.4.3"
+lru = "0.12.3"
+num-traits = { version = "0.2", default-features = false }
+once_cell = "1.19.0"
 rayon = "1.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ members = [
 
 [workspace.dependencies]
 fluence-fendermint-shared = { path = "./shared", version = "0.1.1" }
+randomx-rust-wrapper = "0.1.3"
 
 fvm = { version = "4.1.0", default-features = false }
 fvm_shared = "4.1.0"
 fvm_sdk = "4.1.0"
 num-traits = { version = "0.2", default-features = false }
 
-randomx-rust-wrapper = "0.1.3"
+rayon = "1.8.0"

--- a/fluence-actor-sdk/Cargo.toml
+++ b/fluence-actor-sdk/Cargo.toml
@@ -17,3 +17,4 @@ fluence-fendermint-shared = { workspace = true }
 fvm_shared = { workspace = true }
 fvm_sdk = { workspace = true }
 num-traits = { workspace = true }
+fvm_ipld_encoding = { workspace = true }

--- a/fluence-actor-sdk/src/lib.rs
+++ b/fluence-actor-sdk/src/lib.rs
@@ -51,7 +51,7 @@ pub fn run_randomx(
 pub fn run_randomx_batched(
     global_nonce: &[Vec<u8>],
     local_nonce: &[Vec<u8>],
-) -> Result<[u8; TARGET_HASH_SIZE], fvm_shared::error::ErrorNumber> {
+) -> Result<Vec<[u8; TARGET_HASH_SIZE]>, fvm_shared::error::ErrorNumber> {
     let global_nonce_raw = to_raw(global_nonce);
     let local_nonce_raw = to_raw(local_nonce);
 

--- a/fluence-actor-sdk/src/lib.rs
+++ b/fluence-actor-sdk/src/lib.rs
@@ -75,10 +75,11 @@ pub fn run_randomx_batched(
 }
 
 fn to_raw(array: &[BytesDe]) -> Vec<u32> {
-    array.iter().fold(vec![], |mut acc, v| {
+    let mut acc = Vec::with_capacity(2 * array.len());
+    for v in array {
         // This presumes we are in WASM with 32-bit pointers using Little Endian.
         acc.push(v.0.as_slice().as_ptr() as u32);
         acc.push(v.0.len() as u32);
-        acc
-    })
+    }
+    acc
 }

--- a/fluence-actor-sdk/src/lib.rs
+++ b/fluence-actor-sdk/src/lib.rs
@@ -14,10 +14,21 @@
  * limitations under the License.
  */
 
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![deny(
+    dead_code,
+    nonstandard_style,
+    unused_imports,
+    unused_mut,
+    unused_variables,
+    unused_unsafe,
+    unreachable_patterns
+)]
+
 mod sys;
 
 pub use fluence_fendermint_shared::TARGET_HASH_SIZE;
-pub use fvm_shared::error::ErrorNumber;
 
 /// Run RandomX in the light mode with the supplied global (K) and local (H) nonce,
 /// return its result hash.
@@ -33,4 +44,27 @@ pub fn run_randomx(
             local_nonce.len() as u32,
         )
     }
+}
+
+/// Run RandomX in the light mode with the supplied global (K) and local (H) nonce,
+/// return its result hash.
+pub fn run_randomx_batched(
+    global_nonce: &[Vec<u8>],
+    local_nonce: &[Vec<u8>],
+) -> Result<[u8; TARGET_HASH_SIZE], fvm_shared::error::ErrorNumber> {
+    let global_nonce_raw = to_raw(global_nonce);
+    let local_nonce_raw = to_raw(local_nonce);
+
+    unsafe {
+        sys::run_randomx_batched(
+            global_nonce_raw.as_ptr(),
+            global_nonce_raw.len() as u32,
+            local_nonce_raw.as_ptr(),
+            local_nonce_raw.len() as u32,
+        )
+    }
+}
+
+fn to_raw(array: &[Vec<u8>]) -> Vec<(*const u8, usize)> {
+    array.iter().map(|v| (v.as_ptr(), v.len())).collect::<_>()
 }

--- a/fluence-actor-sdk/src/sys.rs
+++ b/fluence-actor-sdk/src/sys.rs
@@ -31,7 +31,7 @@ fvm_syscalls! {
     pub fn run_randomx_batched(
         global_nonce_addr: *const u32,
         global_nonce_len: u32,
-        local_nonce_addr:*const u32,
+        local_nonce_addr: *const u32,
         local_nonce_len: u32,
     ) -> Result<[u8; crate::BATCHED_HASHES_BYTE_SIZE]>;
 }

--- a/fluence-actor-sdk/src/sys.rs
+++ b/fluence-actor-sdk/src/sys.rs
@@ -30,8 +30,8 @@ fvm_syscalls! {
     #[allow(improper_ctypes)]
     pub fn run_randomx_batched(
         global_nonce_addr: *const u32,
-        global_nonce_len: u32,
+        global_nonce_count: u32,
         local_nonce_addr: *const u32,
-        local_nonce_len: u32,
+        local_nonce_count: u32,
     ) -> Result<[u8; crate::BATCHED_HASHES_BYTE_SIZE]>;
 }

--- a/fluence-actor-sdk/src/sys.rs
+++ b/fluence-actor-sdk/src/sys.rs
@@ -29,9 +29,9 @@ fvm_syscalls! {
 
     #[allow(improper_ctypes)]
     pub fn run_randomx_batched(
-        global_nonce_addr: *const (*const u8, usize),
+        global_nonce_addr: *const u32,
         global_nonce_len: u32,
-        local_nonce_addr: *const (*const u8, usize),
+        local_nonce_addr:*const u32,
         local_nonce_len: u32,
-    ) -> Result<Vec<[u8; crate::TARGET_HASH_SIZE]>>;
+    ) -> Result<[u8; crate::BATCHED_HASHES_BYTE_SIZE]>;
 }

--- a/fluence-actor-sdk/src/sys.rs
+++ b/fluence-actor-sdk/src/sys.rs
@@ -26,4 +26,12 @@ fvm_syscalls! {
         local_nonce_addr: *const u8,
         local_nonce_len: u32,
     ) -> Result<[u8; crate::TARGET_HASH_SIZE]>;
+
+    #[allow(improper_ctypes)]
+    pub fn run_randomx_batched(
+        global_nonce_addr: *const (*const u8, usize),
+        global_nonce_len: u32,
+        local_nonce_addr: *const (*const u8, usize),
+        local_nonce_len: u32,
+    ) -> Result<[u8; crate::TARGET_HASH_SIZE]>;
 }

--- a/fluence-actor-sdk/src/sys.rs
+++ b/fluence-actor-sdk/src/sys.rs
@@ -33,5 +33,5 @@ fvm_syscalls! {
         global_nonce_len: u32,
         local_nonce_addr: *const (*const u8, usize),
         local_nonce_len: u32,
-    ) -> Result<[u8; crate::TARGET_HASH_SIZE]>;
+    ) -> Result<Vec<[u8; crate::TARGET_HASH_SIZE]>>;
 }

--- a/fluence-fendermint-syscall/Cargo.toml
+++ b/fluence-fendermint-syscall/Cargo.toml
@@ -16,5 +16,9 @@ ccp-shared = { workspace = true }
 fvm = { workspace = true }
 fvm_shared = { workspace = true }
 
-rayon = { workspace = true }
+dashmap = { workspace = true }
 num-traits = { workspace = true }
+once_cell = { workspace = true }
+rayon = { workspace = true }
+lru = { workspace = true }
+hex = { workspace = true }

--- a/fluence-fendermint-syscall/Cargo.toml
+++ b/fluence-fendermint-syscall/Cargo.toml
@@ -10,9 +10,10 @@ publish = true
 
 [dependencies]
 fluence-fendermint-shared = { workspace = true }
+randomx-rust-wrapper = { workspace = true }
 
 fvm = { workspace = true }
 fvm_shared = { workspace = true }
-num-traits = { workspace = true }
 
-randomx-rust-wrapper = { workspace = true }
+rayon = { workspace = true }
+num-traits = { workspace = true }

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![deny(
+    dead_code,
+    nonstandard_style,
+    unused_imports,
+    unused_mut,
+    unused_variables,
+    unused_unsafe,
+    unreachable_patterns
+)]
+
 use num_traits::cast::FromPrimitive;
+use std::fmt::Display;
 
 use randomx_rust_wrapper::cache::Cache;
 use randomx_rust_wrapper::flags::RandomXFlags;
@@ -31,6 +44,8 @@ pub use fluence_fendermint_shared::SYSCALL_MODULE_NAME;
 pub use fluence_fendermint_shared::TARGET_HASH_SIZE;
 
 const RANDOMX_SYSCALL_ERROR_CODE: u32 = 0x10000001;
+const INVALID_LENGTH_ERROR_CODE: u32 = 0x10000002;
+const ARGUMENTS_HAVE_DIFFERENT_LENGTH_ERROR_CODE: u32 = 0x10000002;
 
 pub fn run_randomx(
     context: Context<'_, impl Kernel>,
@@ -47,17 +62,92 @@ pub fn run_randomx(
         .try_slice(local_nonce_addr, local_nonce_len)?;
 
     let randomx_flags = RandomXFlags::recommended();
-    let cache = Cache::new(global_nonce, randomx_flags).map_err(|e| {
-        let error_number = ErrorNumber::from_u32(RANDOMX_SYSCALL_ERROR_CODE).unwrap();
-        let syscall_error = SyscallError::new(error_number, e);
-        ExecutionError::Syscall(syscall_error)
-    })?;
-    let vm = RandomXVM::light(&cache, randomx_flags).map_err(|e| {
-        let error_number = ErrorNumber::from_u32(RANDOMX_SYSCALL_ERROR_CODE).unwrap();
-        let syscall_error = SyscallError::new(error_number, e);
-        ExecutionError::Syscall(syscall_error)
-    })?;
+    compute_randomx_hash(randomx_flags, global_nonce, local_nonce)
+}
 
-    let result_hash = vm.hash(local_nonce);
-    Ok(result_hash.into_slice())
+pub fn run_randomx_batched(
+    context: Context<'_, impl Kernel>,
+    global_nonce_addr: u32,
+    global_nonces_len: u32,
+    local_nonce_addr: u32,
+    local_nonces_len: u32,
+) -> Result<Vec<[u8; TARGET_HASH_SIZE]>, ExecutionError> {
+    use rayon::prelude::*;
+
+    if global_nonces_len != local_nonces_len {
+        return Err(execution_error(
+            ARGUMENTS_HAVE_DIFFERENT_LENGTH_ERROR_CODE,
+            format!(
+                "global_nonces length {local_nonces_len}, local_nonces length {global_nonces_len}"
+            ),
+        ));
+    }
+
+    let global_nonces = from_raw(&context, global_nonce_addr, global_nonces_len)?;
+    let local_nonces = from_raw(&context, local_nonce_addr, local_nonces_len)?;
+
+    let randomx_flags = RandomXFlags::recommended();
+
+    let result = global_nonces
+        .par_iter()
+        .zip(local_nonces.par_iter())
+        .map(|(local_nonce, global_nonce)| {
+            compute_randomx_hash(randomx_flags, global_nonce, local_nonce)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(result)
+}
+
+fn compute_randomx_hash(
+    randomx_flags: RandomXFlags,
+    global_nonce: &[u8],
+    local_nonce: &[u8],
+) -> Result<[u8; TARGET_HASH_SIZE], ExecutionError> {
+    let cache = Cache::new(global_nonce, randomx_flags)
+        .map_err(|e| execution_error(RANDOMX_SYSCALL_ERROR_CODE, e))?;
+    let vm = RandomXVM::light(&cache, randomx_flags)
+        .map_err(|e| execution_error(RANDOMX_SYSCALL_ERROR_CODE, e))?;
+
+    Ok(vm.hash(local_nonce).into_slice())
+}
+
+fn from_raw(
+    context: &Context<'_, impl Kernel>,
+    offset: u32,
+    len: u32,
+) -> Result<Vec<Vec<u8>>, ExecutionError> {
+    use fvm::kernel::ClassifyResult;
+
+    if len % 8 != 0 {
+        return Err(execution_error(
+            INVALID_LENGTH_ERROR_CODE,
+            format!("array length is {}, it's not dividable by 8", len),
+        ));
+    }
+
+    let raw_result = context
+        .memory
+        .get(offset as usize..)
+        .and_then(|data| data.get(..len as usize))
+        .ok_or_else(|| format!("buffer {} (length {}) out of bounds", offset, len))
+        .or_error(ErrorNumber::IllegalArgument)?;
+
+    let mut result = Vec::new();
+    for pair_id in 0..len / 8 {
+        let id = (pair_id * 8) as usize;
+        let addr = u32::from_le_bytes(raw_result[id..(id + 4)].try_into().unwrap());
+        let length = u32::from_le_bytes(raw_result[id + 4..id + 8].try_into().unwrap());
+
+        let result_ = unsafe { Vec::from_raw_parts(addr as _, length as usize, length as usize) };
+        result.push(result_)
+    }
+
+    Ok(result)
+}
+
+fn execution_error(error_code: u32, message: impl Display) -> ExecutionError {
+    let error_number = ErrorNumber::from_u32(error_code).unwrap();
+    let syscall_error = SyscallError::new(error_number, message);
+    ExecutionError::Syscall(syscall_error)
 }

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -26,8 +26,16 @@
     unreachable_patterns
 )]
 
+use ccp_randomx::cache::CacheHandle;
+use dashmap::DashMap;
+use fluence_fendermint_shared::BATCHED_HASHES_BYTE_SIZE;
+use lru::LruCache;
 use num_traits::cast::FromPrimitive;
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
 use std::fmt::Display;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
 
 use ccp_randomx::cache::Cache;
 use ccp_randomx::flags::RandomXFlags;
@@ -44,9 +52,23 @@ pub use fluence_fendermint_shared::SYSCALL_FUNCTION_NAME;
 pub use fluence_fendermint_shared::SYSCALL_MODULE_NAME;
 pub use fluence_fendermint_shared::TARGET_HASH_SIZE;
 
+const ERRORS_BASE: u32 = 0x10000000;
 const RANDOMX_SYSCALL_ERROR_CODE: u32 = 0x10000001;
 const INVALID_LENGTH_ERROR_CODE: u32 = 0x10000002;
 const ARGUMENTS_HAVE_DIFFERENT_LENGTH_ERROR_CODE: u32 = 0x10000002;
+// Cache size can be calculated as
+// q99_batch_processing_time * number_of_concurrent_batches floating in the network
+// meanwhile LRU size is just big.
+const RANDOMX_HASH_LRU_CACHE_SIZE: usize = 1024;
+
+type RandomXHash = [u8; 32];
+type RandomXHashLruMutex = Mutex<LruCache<(Vec<u8>, Vec<u8>), RandomXHash>>;
+
+static RANDOMX_HASH_LRU_CACHE: Lazy<RandomXHashLruMutex> = Lazy::new(|| {
+    Mutex::new(LruCache::new(
+        NonZeroUsize::new(RANDOMX_HASH_LRU_CACHE_SIZE).expect("LRU max size must be non-zero"),
+    ))
+});
 
 pub fn run_randomx(
     context: Context<'_, impl Kernel>,
@@ -68,13 +90,14 @@ pub fn run_randomx(
 
 pub fn run_randomx_batched(
     context: Context<'_, impl Kernel>,
+    // Pointer to vector of global nonces represented as Vec<Vec<u8>>.
     global_nonce_addr: u32,
     global_nonces_len: u32,
+    // Pointer to vector of local nonces represented as Vec<Vec<u8>>.
     local_nonce_addr: u32,
     local_nonces_len: u32,
-) -> Result<Vec<[u8; TARGET_HASH_SIZE]>, ExecutionError> {
-    use rayon::prelude::*;
-
+) -> Result<[u8; BATCHED_HASHES_BYTE_SIZE], ExecutionError> {
+    // Byte length of arrays must be equal.
     if global_nonces_len != local_nonces_len {
         return Err(execution_error(
             ARGUMENTS_HAVE_DIFFERENT_LENGTH_ERROR_CODE,
@@ -87,17 +110,147 @@ pub fn run_randomx_batched(
     let global_nonces = from_raw(&context, global_nonce_addr, global_nonces_len)?;
     let local_nonces = from_raw(&context, local_nonce_addr, local_nonces_len)?;
 
-    let randomx_flags = RandomXFlags::recommended();
+    let hashes = compute_randomx_hashes(global_nonces, local_nonces)?;
 
-    let result = global_nonces
-        .par_iter()
-        .zip(local_nonces.par_iter())
-        .map(|(local_nonce, global_nonce)| {
-            compute_randomx_hash(randomx_flags, global_nonce, local_nonce)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    // Pack the Vec<RandomXHash> into a single [u8; BATCHED_HASHES_BYTE_SIZE]
+    let result = [0u8; BATCHED_HASHES_BYTE_SIZE];
+
+    let result = hashes
+        .iter()
+        .enumerate()
+        .fold(result, |mut acc, (idx, hash)| {
+            let array_idx = idx * TARGET_HASH_SIZE;
+            acc[array_idx..array_idx + TARGET_HASH_SIZE].copy_from_slice(hash);
+            acc
+        });
 
     Ok(result)
+}
+
+fn compute_randomx_hashes(
+    global_nonces: Vec<&[u8]>,
+    local_nonces: Vec<&[u8]>,
+) -> Result<Vec<RandomXHash>, ExecutionError> {
+    let randomx_flags = RandomXFlags::recommended();
+
+    let (global_and_local_nonces, cache_results) =
+        get_filtered_nonces_and_cached_results(&global_nonces, &local_nonces);
+
+    let unique_global_nonces = get_unique_global_nonces(&global_and_local_nonces);
+
+    let unique_caches = get_unique_randomx_caches(&unique_global_nonces, randomx_flags);
+
+    let hashes = compute_or_use_cached_randomx_hashes(
+        &global_and_local_nonces,
+        &cache_results,
+        randomx_flags,
+        &unique_caches,
+    )?;
+
+    update_randomx_lru_cache(&global_and_local_nonces, &hashes);
+
+    Ok(hashes)
+}
+
+fn compute_or_use_cached_randomx_hashes<'nonces>(
+    global_and_local_nonces: &Vec<Option<(&'nonces [u8], &'nonces [u8])>>,
+    cache_results: &Vec<Option<RandomXHash>>,
+    randomx_flags: RandomXFlags,
+    unique_caches: &DashMap<&'nonces [u8], Cache>,
+) -> Result<Vec<RandomXHash>, ExecutionError> {
+    use rayon::prelude::*;
+
+    let hashes = global_and_local_nonces
+        .par_iter()
+        .zip(cache_results.par_iter())
+        .map(|(global_and_local_nonce, cache_result)| {
+            match (global_and_local_nonce, cache_result) {
+                (Some((global_nonce, local_nonce)), None) => compute_randomx_hash_with_cache(
+                    randomx_flags,
+                    unique_caches
+                        .get(global_nonce)
+                        .map(|cache| cache.handle())
+                        .unwrap(),
+                    local_nonce,
+                ),
+                (None, Some(cached_hash)) => Ok(*cached_hash), // remove unwrap
+                _ => unreachable!("There must be either calculated or cached RandomX hash."),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(hashes)
+}
+
+fn get_unique_randomx_caches(
+    unique_global_nonces: &HashSet<Vec<u8>>,
+    randomx_flags: RandomXFlags,
+) -> DashMap<&[u8], Cache> {
+    use rayon::prelude::*;
+
+    let unique_caches: DashMap<&[u8], Cache> = DashMap::new();
+
+    unique_global_nonces
+        .par_iter()
+        .for_each(|unique_global_nonce| {
+            let cache = Cache::new(unique_global_nonce, randomx_flags)
+                .expect("There must be no error creating RandomX Cache.");
+            unique_caches.insert(unique_global_nonce, cache);
+        });
+    unique_caches
+}
+
+fn get_unique_global_nonces(
+    global_and_local_nonces: &[Option<(&[u8], &[u8])>],
+) -> HashSet<Vec<u8>> {
+    let unique_global_nonces: HashSet<Vec<u8>> = global_and_local_nonces
+        .iter()
+        .filter_map(|el| el.as_ref().map(|(global, _)| (*global).to_owned()))
+        .collect();
+    unique_global_nonces
+}
+
+fn get_filtered_nonces_and_cached_results<'global, 'local>(
+    global_nonces: &[&'global [u8]],
+    local_nonces: &[&'local [u8]],
+) -> (
+    Vec<Option<(&'global [u8], &'local [u8])>>,
+    Vec<Option<RandomXHash>>,
+) {
+    let mut cache_hash_lru = RANDOMX_HASH_LRU_CACHE.lock().unwrap();
+    global_nonces.iter().zip(local_nonces.iter()).fold(
+        (vec![], vec![]),
+        |(mut global_and_local_nonces, mut cache_results), (&global, &local)| {
+            let cache_result = cache_hash_lru.get(&(global.into(), local.into()));
+            match cache_result {
+                Some(result) => {
+                    global_and_local_nonces.push(None);
+                    cache_results.push(Some(result.to_owned()));
+                }
+                None => {
+                    global_and_local_nonces.push(Some((global, local)));
+                    cache_results.push(None);
+                }
+            }
+
+            (global_and_local_nonces, cache_results)
+        },
+    )
+}
+
+fn update_randomx_lru_cache(
+    global_and_local_nonces: &[Option<(&[u8], &[u8])>],
+    hashes: &[RandomXHash],
+) {
+    let mut cache_hash_lru = RANDOMX_HASH_LRU_CACHE.lock().unwrap();
+
+    for (local_and_global_nonces, hash) in global_and_local_nonces.iter().zip(hashes.iter()) {
+        if let Some((global_nonce, local_nonce)) = local_and_global_nonces {
+            let _ = cache_hash_lru.put(
+                ((*global_nonce).to_owned(), (*local_nonce).to_owned()),
+                *hash,
+            );
+        }
+    }
 }
 
 fn compute_randomx_hash(
@@ -113,13 +266,27 @@ fn compute_randomx_hash(
     Ok(vm.hash(local_nonce).into_slice())
 }
 
-fn from_raw(
-    context: &Context<'_, impl Kernel>,
+fn compute_randomx_hash_with_cache(
+    randomx_flags: RandomXFlags,
+    cache: CacheHandle,
+    local_nonce: &[u8],
+) -> Result<[u8; TARGET_HASH_SIZE], ExecutionError> {
+    let vm = RandomXVM::light(cache, randomx_flags)
+        .map_err(|e| execution_error(RANDOMX_SYSCALL_ERROR_CODE, e))?;
+
+    Ok(vm.hash(local_nonce).into_slice())
+}
+
+fn from_raw<'context>(
+    context: &'context Context<'_, impl Kernel>,
     offset: u32,
     len: u32,
-) -> Result<Vec<Vec<u8>>, ExecutionError> {
+) -> Result<Vec<&'context [u8]>, ExecutionError> {
     use fvm::kernel::ClassifyResult;
 
+    // Here we process (u32, u32) pairs array created by SDK part in WASM.
+    // The first u32 is a pointer to nonce buffer, the second u32 is a length of nonce buffer.
+    // This invariant means that every (u32,u32) pair uses 4 + 4 bytes.
     if len % 8 != 0 {
         return Err(execution_error(
             INVALID_LENGTH_ERROR_CODE,
@@ -127,6 +294,7 @@ fn from_raw(
         ));
     }
 
+    // Get the outter array data from the memory allocated in wasm runtime.
     let raw_result = context
         .memory
         .get(offset as usize..)
@@ -135,20 +303,198 @@ fn from_raw(
         .or_error(ErrorNumber::IllegalArgument)?;
 
     let mut result = Vec::new();
+    // Process the array of (u32, u32) pairs.
     for pair_id in 0..len / 8 {
         let id = (pair_id * 8) as usize;
+        // This presumes we are in WASM with 32-bit pointers using Little Endian.
         let addr = u32::from_le_bytes(raw_result[id..(id + 4)].try_into().unwrap());
         let length = u32::from_le_bytes(raw_result[id + 4..id + 8].try_into().unwrap());
 
-        let result_ = unsafe { Vec::from_raw_parts(addr as _, length as usize, length as usize) };
-        result.push(result_)
+        // Get Nonce buffer from the memory allocated in wasm runtime.
+        let nonce_buf_from_wasm = context.memory.try_slice(addr, length)?;
+        result.push(nonce_buf_from_wasm)
     }
 
     Ok(result)
 }
 
 fn execution_error(error_code: u32, message: impl Display) -> ExecutionError {
-    let error_number = ErrorNumber::from_u32(error_code).unwrap();
+    let error_number = ErrorNumber::from_u32(error_code - ERRORS_BASE).unwrap();
     let syscall_error = SyscallError::new(error_number, message);
     ExecutionError::Syscall(syscall_error)
+}
+
+#[cfg(test)]
+mod tests {
+
+    use ccp_shared::types::{GlobalNonce, LocalNonce};
+
+    use crate::compute_randomx_hashes;
+    use crate::get_filtered_nonces_and_cached_results;
+    use crate::update_randomx_lru_cache;
+    use crate::RandomXHash;
+    use crate::RANDOMX_HASH_LRU_CACHE;
+
+    fn clear_hash_lru_cache() {
+        let mut cache_hash_lru = RANDOMX_HASH_LRU_CACHE.lock().unwrap();
+        cache_hash_lru.clear();
+    }
+
+    #[test]
+    fn compute_randomx_hashes_simple() {
+        let hex_array: RandomXHash = [
+            0x7a, 0x55, 0xef, 0x51, 0x4e, 0x78, 0x14, 0x7c, 0xed, 0x93, 0x28, 0x21, 0x0a, 0x5a,
+            0x83, 0x25, 0x2c, 0xaf, 0xa8, 0x96, 0x1e, 0xa1, 0x42, 0x99, 0x4b, 0xe7, 0xbb, 0x85,
+            0x18, 0xf6, 0x11, 0x32,
+        ];
+        let local_nonce = LocalNonce::new(hex_array);
+
+        let global_nonces = (0..4)
+            .into_iter()
+            .map(|i| {
+                let mut hex_array: RandomXHash = [
+                    0x06, 0x48, 0xfb, 0x77, 0x5e, 0x2c, 0x0a, 0xcd, 0xe0, 0xa6, 0x67, 0x09, 0x32,
+                    0x89, 0x1c, 0xc5, 0x92, 0x3a, 0x86, 0xba, 0x00, 0x66, 0x25, 0x21, 0x0b, 0x1f,
+                    0xc7, 0xc9, 0x1a, 0x04, 0x47, 0x4c,
+                ];
+                hex_array[0] += i;
+                GlobalNonce::new(hex_array)
+            })
+            .collect::<Vec<_>>();
+
+        for _ in 0..5 {
+            let global_nonces = global_nonces
+                .iter()
+                .map(|g_n| g_n.as_ref() as &[u8])
+                .collect::<Vec<_>>();
+            let _ = compute_randomx_hashes(global_nonces, vec![local_nonce.as_ref()]);
+            println!();
+        }
+    }
+
+    #[test]
+    fn get_filtered_nonces_and_cached_results_w_empty_cache() {
+        let nonces_num: usize = 5;
+        let local_nonces = (0..nonces_num)
+            .into_iter()
+            .map(|_| LocalNonce::random())
+            .collect::<Vec<_>>();
+
+        let local_nonces_bufs = local_nonces
+            .iter()
+            .map(|l_n| l_n.as_ref() as &[u8])
+            .collect::<Vec<_>>();
+
+        let global_nonces = (0..nonces_num)
+            .into_iter()
+            .map(|i| {
+                let mut hex_array: RandomXHash = [
+                    0x06, 0x48, 0xfb, 0x77, 0x5e, 0x2c, 0x0a, 0xcd, 0xe0, 0xa6, 0x67, 0x09, 0x32,
+                    0x89, 0x1c, 0xc5, 0x92, 0x3a, 0x86, 0xba, 0x00, 0x66, 0x25, 0x21, 0x0b, 0x1f,
+                    0xc7, 0xc9, 0x1a, 0x04, 0x47, 0x4c,
+                ];
+                hex_array[0] += i as u8;
+                GlobalNonce::new(hex_array)
+            })
+            .collect::<Vec<_>>();
+        let global_nonces_bufs = global_nonces
+            .iter()
+            .map(|g_n| g_n.as_ref() as &[u8])
+            .collect::<Vec<_>>();
+
+        let (filtered_nonces, cached_hashes) =
+            get_filtered_nonces_and_cached_results(&global_nonces_bufs, &local_nonces_bufs);
+
+        assert_eq!(filtered_nonces.len(), nonces_num);
+        assert_eq!(cached_hashes.len(), nonces_num);
+        cached_hashes
+            .iter()
+            .for_each(|cached_hash| assert!(cached_hash.is_none()));
+        filtered_nonces
+            .iter()
+            .for_each(|nonces| assert!(nonces.is_some()));
+    }
+
+    #[test]
+    fn get_filtered_nonces_and_cached_results_non_empty_cache() {
+        let nonces_num: usize = 5;
+        let local_nonces = (0..nonces_num)
+            .into_iter()
+            .map(|_| LocalNonce::random())
+            .collect::<Vec<_>>();
+
+        let local_nonces_bufs = local_nonces
+            .iter()
+            .map(|l_n| l_n.as_ref() as &[u8])
+            .collect::<Vec<_>>();
+
+        let global_nonces = (0..nonces_num)
+            .into_iter()
+            .map(|i| {
+                let mut hex_array: RandomXHash = [
+                    0x06, 0x48, 0xfb, 0x77, 0x5e, 0x2c, 0x0a, 0xcd, 0xe0, 0xa6, 0x67, 0x09, 0x32,
+                    0x89, 0x1c, 0xc5, 0x92, 0x3a, 0x86, 0xba, 0x00, 0x66, 0x25, 0x21, 0x0b, 0x1f,
+                    0xc7, 0xc9, 0x1a, 0x04, 0x47, 0x4c,
+                ];
+                hex_array[0] += i as u8;
+                GlobalNonce::new(hex_array)
+            })
+            .collect::<Vec<_>>();
+        let global_nonces_bufs = global_nonces
+            .iter()
+            .map(|g_n| g_n.as_ref() as &[u8])
+            .collect::<Vec<_>>();
+
+        let global_nonce = global_nonces[0].as_ref() as &[u8];
+        let local_nonce = local_nonces[0].as_ref() as &[u8];
+        let nonces = vec![Some((global_nonce, local_nonce))];
+        let hashes = vec![[0u8; 32]];
+        update_randomx_lru_cache(&nonces, &hashes);
+
+        let (filtered_nonces, cached_hashes) =
+            get_filtered_nonces_and_cached_results(&global_nonces_bufs, &local_nonces_bufs);
+
+        assert_eq!(filtered_nonces.len(), nonces_num);
+        assert_eq!(cached_hashes.len(), nonces_num);
+        assert!(filtered_nonces[0].is_none());
+        filtered_nonces
+            .iter()
+            .skip(1)
+            .for_each(|nonces| assert!(nonces.is_some()));
+        assert!(cached_hashes[0].is_some());
+        cached_hashes
+            .iter()
+            .skip(1)
+            .for_each(|cached| assert!(cached.is_none()));
+
+        clear_hash_lru_cache();
+    }
+
+    #[test]
+    fn update_randomx_lru_cache_no_options() {
+        let nonce = LocalNonce::random();
+        let nonce_buf = nonce.as_ref() as &[u8];
+        let nonces = vec![Some((nonce_buf, nonce_buf))];
+        let hashes = vec![[0u8; 32]];
+
+        clear_hash_lru_cache();
+
+        update_randomx_lru_cache(&nonces, &hashes);
+        {
+            let cache_hash_lru = RANDOMX_HASH_LRU_CACHE.lock().unwrap();
+            assert_eq!(cache_hash_lru.len(), 1);
+        }
+
+        let nonce = LocalNonce::random();
+        let nonce_buf = nonce.as_ref() as &[u8];
+        let nonces = vec![Some((nonce_buf, nonce_buf))];
+        update_randomx_lru_cache(&nonces, &hashes);
+
+        {
+            let cache_hash_lru = RANDOMX_HASH_LRU_CACHE.lock().unwrap();
+            assert_eq!(cache_hash_lru.len(), 2);
+        }
+
+        clear_hash_lru_cache();
+    }
 }

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -61,8 +61,8 @@ const TOO_MANY_HASHES_ERROR_CODE: u32 = ERRORS_BASE | 3;
 // meanwhile LRU size is just big.
 const RANDOMX_HASH_LRU_CACHE_SIZE: usize = 1024;
 
-const CACHE_HAS_ELEMENT: &str = "cache has requested element, which enforced by checks";
-const IT_IS_SAFE_TO_LOCK_CACHE: &str = "global cache is save to lock, it's done in single thread";
+const CACHE_HAS_ELEMENT: &str = "cache has requested element, which is enforced by checks";
+const IT_IS_SAFE_TO_LOCK_CACHE: &str = "global cache is safe to lock, it's done in single thread";
 const RAW_OFFSET_AND_LEN_ARE_WELL_DEFINED: &str = "offsets and lengths of nonces are well defined";
 
 type RandomXHash = [u8; 32];

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -29,7 +29,7 @@
 use ccp_randomx::cache::CacheHandle;
 use dashmap::DashMap;
 use fluence_fendermint_shared::BATCHED_HASHES_BYTE_SIZE;
-use fluence_fendermint_shared::HASHES_BATCH_SIZE;
+use fluence_fendermint_shared::MAX_HASHES_BATCH_SIZE;
 use lru::LruCache;
 use num_traits::cast::FromPrimitive;
 use once_cell::sync::Lazy;
@@ -113,10 +113,10 @@ pub fn run_randomx_batched(
         ));
     }
 
-    if (global_nonces_len as usize) > HASHES_BATCH_SIZE {
+    if (global_nonces_len as usize) > MAX_HASHES_BATCH_SIZE {
         return Err(execution_error(
             INVALID_LENGTH_ERROR_CODE,
-            format!("global_nonces length {global_nonces_len} cannot be larger than {HASHES_BATCH_SIZE}"),
+            format!("global_nonces length {global_nonces_len} cannot be larger than {MAX_HASHES_BATCH_SIZE}"),
         ));
     }
 

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -152,7 +152,7 @@ pub fn run_randomx_batched(
 
     let overall_actor_duration = overall_actor_start_time.elapsed();
     println!(
-        "randomx_batched_duration: overall_actor_time {}",
+        "randomx_batched_duration: overall_actor_time took {}",
         overall_actor_duration.as_millis()
     );
 

--- a/fluence-fendermint-syscall/src/lib.rs
+++ b/fluence-fendermint-syscall/src/lib.rs
@@ -39,6 +39,7 @@ use fvm::kernel::SyscallError;
 use fvm::syscalls::Context;
 use fvm_shared::error::ErrorNumber;
 
+pub use fluence_fendermint_shared::BATCHED_SYSCALL_FUNCTION_NAME;
 pub use fluence_fendermint_shared::SYSCALL_FUNCTION_NAME;
 pub use fluence_fendermint_shared::SYSCALL_MODULE_NAME;
 pub use fluence_fendermint_shared::TARGET_HASH_SIZE;

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -36,6 +36,12 @@ pub const SYSCALL_MODULE_NAME: &str = "fluence";
 /// which will be used to call the actual syscall implementation.
 pub const SYSCALL_FUNCTION_NAME: &str = "run_randomx";
 
+/// Size of a batched RandomX invocation result.
+pub const HASHES_BATCH_SIZE: usize = 256;
+
+/// Size in bytes of a batched RandomX invocation result.
+pub const BATCHED_HASHES_BYTE_SIZE: usize = HASHES_BATCH_SIZE * TARGET_HASH_SIZE;
+
 /// Name of a batched version of import function (syscall)
 /// which will be used to call the actual syscall implementation.
 pub const BATCHED_SYSCALL_FUNCTION_NAME: &str = "run_randomx_batched";

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -37,10 +37,10 @@ pub const SYSCALL_MODULE_NAME: &str = "fluence";
 pub const SYSCALL_FUNCTION_NAME: &str = "run_randomx";
 
 /// Size of a batched RandomX invocation result.
-pub const HASHES_BATCH_SIZE: usize = 256;
+pub const MAX_HASHES_BATCH_SIZE: usize = 512;
 
 /// Size in bytes of a batched RandomX invocation result.
-pub const BATCHED_HASHES_BYTE_SIZE: usize = HASHES_BATCH_SIZE * TARGET_HASH_SIZE;
+pub const BATCHED_HASHES_BYTE_SIZE: usize = MAX_HASHES_BATCH_SIZE * TARGET_HASH_SIZE;
 
 /// Name of a batched version of import function (syscall)
 /// which will be used to call the actual syscall implementation.

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -35,3 +35,7 @@ pub const SYSCALL_MODULE_NAME: &str = "fluence";
 /// Name of the import function (syscall)
 /// which will be used to call the actual syscall implementation.
 pub const SYSCALL_FUNCTION_NAME: &str = "run_randomx";
+
+/// Name of a batched version of import function (syscall)
+/// which will be used to call the actual syscall implementation.
+pub const BATCHED_SYSCALL_FUNCTION_NAME: &str = "run_randomx_batched";

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+#![warn(rust_2018_idioms)]
+#![warn(rust_2021_compatibility)]
+#![deny(
+    dead_code,
+    nonstandard_style,
+    unused_imports,
+    unused_mut,
+    unused_variables,
+    unused_unsafe,
+    unreachable_patterns
+)]
+
 /// Size in bytes of a result of RandomX invocation, which is basically a hash.
 pub const TARGET_HASH_SIZE: usize = 32;
 


### PR DESCRIPTION
This patch both incorporates @mikevoronov work on batch processing with some extra additions:
- syscall API had change according with the spec used by IPC actors API
- syscall uses static global LRU cache stores computed RandomX caches to avoid duplicate calculations
- syscall groups by (global, local) in a batch to reduce a number of RandomX cache init calls