### PR TITLE
fix: return back run_randomx signature

### DIFF
--- a/fluence-actor-sdk/src/lib.rs
+++ b/fluence-actor-sdk/src/lib.rs
@@ -35,8 +35,8 @@ use fvm_ipld_encoding::BytesDe;
 /// Run RandomX in the light mode with the supplied global (K) and local (H) nonce,
 /// return its result hash.
 pub fn run_randomx(
-    global_nonce: &[u8],
-    local_nonce: &[u8],
+    global_nonce: Vec<u8>,
+    local_nonce: Vec<u8>,
 ) -> Result<[u8; TARGET_HASH_SIZE], fvm_shared::error::ErrorNumber> {
     unsafe {
         sys::run_randomx(


### PR DESCRIPTION
It's needed to make Fluence actor and Fluence batched actor to depend on one version of the `fluence-fendermint` library.